### PR TITLE
Add `gameId` to badge data

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.2.0] - 2026-03-26
+
+### Added
+- [#31] New required field `gameId` on badge data. Represents the in-game id of the badge for tools like `/build_save`.
+
+
 ## [2.1.0] - 2026-01-20
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,14 +8,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [2.2.0] - 2026-03-26
 
 ### Added
-- [#31] New required field `gameId` on badge data. Represents the in-game id of the badge for tools like `/build_save`.
 
+- [2.2.0] [#31](https://github.com/n15g/coh-content-db/pull/31) - New required field `gameId` on badge data. Represents the in-game id of the badge for tools like `/build_save`.
+
+---
 
 ## [2.1.0] - 2026-01-20
 
 ### Added
 
 - Character origin can now be passed in a variant context to prioritize praetorian-origin variants.
+
+---
 
 ## [2.0.0] - 2026-01-05
 

--- a/src/main/api/badge-data.ts
+++ b/src/main/api/badge-data.ts
@@ -16,7 +16,7 @@ export interface BadgeData {
   readonly key: string
 
   /**
-   * The id used by the game code and the `/buildsave` command.
+   * The id used by the game code and the `/build_save` command.
    */
   readonly gameId: string
 

--- a/src/main/api/badge-data.ts
+++ b/src/main/api/badge-data.ts
@@ -16,6 +16,11 @@ export interface BadgeData {
   readonly key: string
 
   /**
+   * The id used by the game code and the `/buildsave` command.
+   */
+  readonly gameId: string
+
+  /**
    * The type of badge.
    */
   readonly type: BadgeType
@@ -33,7 +38,7 @@ export interface BadgeData {
   readonly releaseDate: string
 
   /**
-   * The {@link MoralityExtended|moralities} that this badge is available to. If undefined then all moralities will be assumed.
+   * The {@link MoralityExtended|moralities} that this badge is available to. If undefined, then all moralities will be assumed.
    */
   readonly morality?: MoralityExtended | MoralityExtended[]
 
@@ -66,7 +71,7 @@ export interface BadgeData {
 
   /**
    * The id used with the in-game `/settitle` command to apply the badge.
-   * The first value is the id for primal characters and the (optional) second number is the id for praetorian characters.
+   * The first value is the id for primal characters, and the (optional) second number is the id for praetorian characters.
    */
   readonly setTitleId?: SetTitleData
 

--- a/src/main/db/badge.ts
+++ b/src/main/db/badge.ts
@@ -22,6 +22,11 @@ export class Badge {
   readonly key: string
 
   /**
+   * The id used by the game code and the `/buildsave` command.
+   */
+  readonly gameId: string
+
+  /**
    * The type of badge.
    */
   readonly type: BadgeType
@@ -72,7 +77,7 @@ export class Badge {
 
   /**
    * The id used with the in-game `/settitle` command to apply the badge.
-   * The first value is the id for primal characters and the (optional) second number is the id for praetorian characters.
+   * The first value is the id for primal characters, and the (optional) second number is the id for praetorian characters.
    */
   readonly setTitleId?: SetTitleIds
 
@@ -88,6 +93,7 @@ export class Badge {
 
   constructor(badgeData: BadgeData) {
     this.key = new Key(badgeData.key).value
+    this.gameId = badgeData.gameId
     this.type = badgeData.type
     this.name = new Variants(badgeData.name)
     this.releaseDate = toDate(badgeData.releaseDate)

--- a/src/main/db/badge.ts
+++ b/src/main/db/badge.ts
@@ -22,7 +22,7 @@ export class Badge {
   readonly key: string
 
   /**
-   * The id used by the game code and the `/buildsave` command.
+   * The id used by the game code and the `/build_save` command.
    */
   readonly gameId: string
 

--- a/src/test/api/badge-data.fixture.ts
+++ b/src/test/api/badge-data.fixture.ts
@@ -3,6 +3,7 @@ import { BADGE_TYPE, BadgeData } from '../../main'
 
 export const badgeDataFixture = defineFixture<BadgeData>((t) => {
   t.key.as(index => `badge-${index}`)
+  t.gameId.as(index => `Badge${index}`)
   t.type.pickFrom([...BADGE_TYPE])
   t.name.as(index => [{ value: `Badge ${index}` }])
   t.releaseDate.as(() => '2025-02-03')

--- a/src/test/api/badge-data.test.ts
+++ b/src/test/api/badge-data.test.ts
@@ -3,6 +3,7 @@ import { BadgeData } from '../../main'
 // If you change this test, update the example in the README as well
 export const TEST_BADGE: BadgeData = {
   key: 'test-badge',
+  gameId: 'TestBadge',
   type: 'achievement',
   name: [{ value: 'Test Badge' }, { alignment: 'praetorian', value: 'My Badge for Praetorians' }],
   releaseDate: '2020-03-01',

--- a/src/test/db/badge.test.ts
+++ b/src/test/db/badge.test.ts
@@ -16,6 +16,13 @@ describe(Badge.name, () => {
     })
   })
 
+  describe('gameId', () => {
+    test('should be set from the data', () => {
+      const badge = new Badge(badgeDataFixture.create({ gameId: 'Badge123' }))
+      expect(badge.gameId).toEqual('Badge123')
+    })
+  })
+
   describe('type', () => {
     test('should be set from the data', () => {
       const badge = new Badge(badgeDataFixture.create({ type: 'achievement' }))


### PR DESCRIPTION
Represents the in-game id for badges, used for things like the `/buildsave` command and internal game logic.